### PR TITLE
required salary field for jobs

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -16,7 +16,7 @@ class Job < ApplicationRecord
 
   default_scope { order(created_at: :desc, published_at: :desc) }
 
-  validates :title, :description, :job_type, presence: true
+  validates :title, :description, :job_type, :salary, presence: true
 
   acts_as_taggable
   before_validation :run_spam_analysis, on: :create


### PR DESCRIPTION
Jobs posted on the [Code4Lib Job Board](https://jobs.code4lib.org/) should require at least some sort of salary statement.

Salary transparency is important to ensure people are appropriately compensated for their work. Seven US states already require salary transparency, and a number of professional organizations require salary information for jobs to be posted, including the Society of American Archivists (SAA), the Association of College and Research Libraries/Rare Books and Manuscripts Section (RBMS), and the Digital Library Federation (DLF). I'm unsure if these job boards have received less postings since these policy changes, but as a user, I have not noticed them becoming any less useful. The SAA Archival Compensation Task Force has [more information](https://www2.archivists.org/sites/all/files/0521-2-III-A-ArchCompTF-SalaryAdvoc.pdf) regarding the [SAA policy change](https://www2.archivists.org/news/2021/saa-council-approves-requirement-for-salary-transparency).

Just requiring the string field may not be an ideal solution, as employers could easily enter text that provides no meaningful salary details. Yet, I feel that just having that little asterisk will go a long way toward encouraging employers to state a salary range. As these posts are moderated, I suspect it would also be feasible to have a stated salary policy, however I'm not sure who the authorizing body for this would be and we would be hesitant to require more of volunteer moderators. Just requiring the field may have much of the desired affect without having another governance process.

Overall, I feel like this is a super easy change that will provide much more salary information to job seekers with little downside risk.