### PR TITLE
[accessibility] Headings on main page should be in order

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -18,7 +18,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-12">
-      <h1><%= link_to 'Recently posted jobs ›', jobs_path, class: 'text-reset' %></h1>
+      <h2><%= link_to 'Recently posted jobs ›', jobs_path, class: 'text-reset' %></h2>
       <%= render 'jobs/table', jobs: @jobs, show_pagination: false %>
       <%= link_to 'View all jobs', jobs_path, class: 'btn btn-primary' %>
     </div>

--- a/app/views/jobs/_table.html.erb
+++ b/app/views/jobs/_table.html.erb
@@ -5,7 +5,7 @@
   <% jobs.each do |job| %>
     <li class="card job position-relative">
       <div class="card-header">
-        <h5 class="card-title"><%= link_to job.title, job, class: 'stretched-link' %></h5>
+        <h3 class="card-title"><%= link_to job.title, job, class: 'stretched-link' %></h3>
         <div class="card-subtitle"><%= safe_join([job.employer&.name, job.location].reject(&:blank?), ' — ') %></div>
       </div>
 


### PR DESCRIPTION
Previously, the main page had two h1 headings, then a bunch of h5 headings. This commit puts them in order by h1, h2, and h3.